### PR TITLE
fix: 정규표현식 포맷 수정

### DIFF
--- a/src/utils/parseSharedRepositoryVersion.ts
+++ b/src/utils/parseSharedRepositoryVersion.ts
@@ -16,8 +16,8 @@ const regexKey = {
 type regexKeyType = typeof regexKey[keyof typeof regexKey];
 
 const regex = {
-  [regexKey.designSystem]: /Published.*?Done/s,
-  [regexKey.frontendLibs]: /packagestopublish:/s,
+  [regexKey.designSystem]: new RegExp("Published.*?Done"),
+  [regexKey.frontendLibs]: new RegExp("packagestopublish:"),
 }
 
 const versionParseFunc = {
@@ -60,7 +60,7 @@ function parseDesignSystemPackageVersion(regExpMatchArr: RegExpMatchArray) {
 
 function parseFrontendLibsPackageVersion(regExpMatchArr: RegExpMatchArray) {
   const versionNote = regExpMatchArr.input?.split(FRONTEND_LIBS_SLPIT_WORD)[1];
-  return versionNote?.split('-@myrealtrip').slice(1).map((item) => `@myrealtrip${item.split('+')[0].replace("=>", "@")}`);
+  return versionNote?.split('-@myrealtrip').slice(1).map((item) => `@myrealtrip${item.split('+')[0].replace("=>", "@")}`) || [];
 }
 
 export function parseProductionVersion(value: string) {


### PR DESCRIPTION
## Changes
파서 오류 수정

## Bug Report
```
(node:3152) UnhandledPromiseRejectionWarning: TypeError: versionParseFunc[keyType] is not a function
    at parseCanaryVersion (/home/ubuntu/actions-runner/_work/_actions/myrealtrip/github-slack-notify-action/v1.10.1/webpack:/frontend-bot/src/utils/parseDesignSystemVersion.ts:27:1)
```